### PR TITLE
Feature/problem list ui

### DIFF
--- a/majifix311/build.gradle
+++ b/majifix311/build.gradle
@@ -41,6 +41,8 @@ dependencies {
     compile 'com.android.support:appcompat-v7:25.4.0'
     compile 'com.android.support:design:25.4.0'
     compile 'com.android.support.constraint:constraint-layout:1.0.2'
+    compile 'com.android.support:recyclerview-v7:25.4.0'
+    compile 'com.android.support:cardview-v7:25.4.0'
 
     compile 'io.reactivex.rxjava2:rxandroid:2.0.1'
     compile 'io.reactivex.rxjava2:rxjava:2.1.3'

--- a/majifix311/src/main/AndroidManifest.xml
+++ b/majifix311/src/main/AndroidManifest.xml
@@ -15,6 +15,11 @@
             android:name=".ui.ReportProblemActivity"
             android:label=""
             android:launchMode="singleTask"/>
+
+        <activity
+            android:name=".ui.ProblemListActivity"
+            android:label=""
+            android:launchMode="singleTask"/>
     </application>
 
 </manifest>

--- a/majifix311/src/main/java/com/example/majifix311/EventHandler.java
+++ b/majifix311/src/main/java/com/example/majifix311/EventHandler.java
@@ -6,12 +6,16 @@ import android.support.v4.content.LocalBroadcastManager;
 
 import com.example.majifix311.models.Problem;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * This is used for sending updates throughout the application.
  */
 
 public class EventHandler {
     public final static String BROADCAST_REPORT_RECIEVED = "com.majifix311.broadcast.REPORT_RECEIVED";
+    public final static String BROADCAST_MY_REPORTED_RECIEVED = "com.majifix311.broadcast.MY_REPORTED_RECEIVED";
     public final static String IS_SUCCESS = "is success";
     public final static String PROBLEM_INTENT = "problem";
     public final static String ERROR_INTENT = "error";
@@ -29,6 +33,16 @@ public class EventHandler {
         resultIntent.setAction(BROADCAST_REPORT_RECIEVED);
         resultIntent.putExtra(IS_SUCCESS, false);
         resultIntent.putExtra(ERROR_INTENT, error);
+        LocalBroadcastManager.getInstance(context).sendBroadcast(resultIntent);
+    }
+
+    public static void sendMyReportedProblemsList(Context context, ArrayList<Problem> problemList) {
+        System.out.println("Sending list of problems: "+problemList.size());
+
+        Intent resultIntent = new Intent();
+        resultIntent.setAction(BROADCAST_MY_REPORTED_RECIEVED);
+        resultIntent.putExtra(IS_SUCCESS, true);
+        resultIntent.putExtra(PROBLEM_INTENT, problemList);
         LocalBroadcastManager.getInstance(context).sendBroadcast(resultIntent);
     }
 

--- a/majifix311/src/main/java/com/example/majifix311/api/ApiModelConverter.java
+++ b/majifix311/src/main/java/com/example/majifix311/api/ApiModelConverter.java
@@ -53,7 +53,8 @@ public class ApiModelConverter {
     public static Category convert(ApiService apiCategory) {
         return new Category(apiCategory.getName(),
                 apiCategory.getId(),
-                apiCategory.getPriority());
+                apiCategory.getPriority(),
+                apiCategory.getCode());
     }
 
     private static ApiServiceRequest convertShared(ApiServiceRequest request, Problem problem) {

--- a/majifix311/src/main/java/com/example/majifix311/api/models/ApiService.java
+++ b/majifix311/src/main/java/com/example/majifix311/api/models/ApiService.java
@@ -65,11 +65,12 @@ public class ApiService {
     private ApiPriority priority;
 
     @VisibleForTesting
-    public ApiService(String id, String name, int priority) {
+    public ApiService(String id, String name, int priority, String code) {
         _id = id;
         this.name = name;
         this.priority = new ApiPriority();
         this.priority.setWeight(priority);
+        this.code = code;
     }
 
     public String getCode() {

--- a/majifix311/src/main/java/com/example/majifix311/db/CategoryContract.java
+++ b/majifix311/src/main/java/com/example/majifix311/db/CategoryContract.java
@@ -58,7 +58,8 @@ class CategoryContract {
         String[] projection =  {
                 Entry.COLUMN_NAME,
                 Entry.COLUMN_ID,
-                Entry.COLUMN_PRIORITY
+                Entry.COLUMN_PRIORITY,
+                Entry.COLUMN_CODE
         };
 
         Cursor cursor = db.query(TABLE_NAME, projection,null,null,null,null,null);
@@ -71,7 +72,9 @@ class CategoryContract {
             String id = cursor.getString(
                     cursor.getColumnIndexOrThrow(Entry.COLUMN_ID));
             int priority = cursor.getInt(cursor.getColumnIndexOrThrow(Entry.COLUMN_PRIORITY));
-            categories.add(new Category(name,id, priority));
+            String code = cursor.getString(
+                    cursor.getColumnIndexOrThrow(Entry.COLUMN_CODE));
+            categories.add(new Category(name,id, priority, code));
         }
         cursor.close();
 

--- a/majifix311/src/main/java/com/example/majifix311/db/ProblemContract.java
+++ b/majifix311/src/main/java/com/example/majifix311/db/ProblemContract.java
@@ -43,6 +43,7 @@ class ProblemContract {
             Entry.COLUMN_CATEGORY_NAME +" TEXT, "+
             Entry.COLUMN_CATEGORY_ID +" TEXT, "+
             Entry.COLUMN_CATEGORY_PRIORITY +" INTEGER, "+
+            Entry.COLUMN_CATEGORY_CODE +" STRING, "+
             Entry.COLUMN_LATITUDE +" DECIMAL, "+
             Entry.COLUMN_LONGITUDE +" DECIMAL, "+
             Entry.COLUMN_ADDRESS +" TEXT, "+
@@ -81,6 +82,7 @@ class ProblemContract {
                 values.put(Entry.COLUMN_CATEGORY_NAME, category.getName());
                 values.put(Entry.COLUMN_CATEGORY_ID, category.getId());
                 values.put(Entry.COLUMN_CATEGORY_PRIORITY, category.getPriority());
+                values.put(Entry.COLUMN_CATEGORY_CODE, category.getCode());
             }
             ApiLocation location = problem.getLocation();
             if (location != null) {
@@ -125,6 +127,7 @@ class ProblemContract {
                 Entry.COLUMN_CATEGORY_NAME,
                 Entry.COLUMN_CATEGORY_ID,
                 Entry.COLUMN_CATEGORY_PRIORITY,
+                Entry.COLUMN_CATEGORY_CODE,
                 Entry.COLUMN_LATITUDE,
                 Entry.COLUMN_LONGITUDE,
                 Entry.COLUMN_ADDRESS,
@@ -167,6 +170,8 @@ class ProblemContract {
                     cursor.getColumnIndexOrThrow(Entry.COLUMN_CATEGORY_ID));
             int categoryPriority = cursor.getInt(
                     cursor.getColumnIndexOrThrow(Entry.COLUMN_CATEGORY_PRIORITY));
+            String categoryCode = cursor.getString(
+                    cursor.getColumnIndexOrThrow(Entry.COLUMN_CATEGORY_CODE));
 
             // location info
             Location location = new Location("");
@@ -210,7 +215,7 @@ class ProblemContract {
             //        cursor.getColumnIndexOrThrow(Entry.COLUMN_COMMENT_JSON));
 
             Problem problem = builder.buildWithoutValidation(username, phone, email, accountNumber,
-                    new Category(categoryName, categoryId, categoryPriority),
+                    new Category(categoryName, categoryId, categoryPriority, categoryCode),
                     location, address, description, ticketNumber,
                     new Status(isOpen, statusName, statusColor),
                     createdAt, updatedAt, resolvedAt, attachments);
@@ -235,6 +240,7 @@ class ProblemContract {
         static final String COLUMN_CATEGORY_NAME = "category_name";
         static final String COLUMN_CATEGORY_ID = "category_id";
         static final String COLUMN_CATEGORY_PRIORITY = "category_priority";
+        static final String COLUMN_CATEGORY_CODE = "category_code";
         static final String COLUMN_LATITUDE = "latitude";
         static final String COLUMN_LONGITUDE = "longitude";
         static final String COLUMN_ADDRESS = "address";

--- a/majifix311/src/main/java/com/example/majifix311/models/Category.java
+++ b/majifix311/src/main/java/com/example/majifix311/models/Category.java
@@ -12,17 +12,20 @@ public class Category implements Parcelable, Comparable<Category> {
     private String mName;
     private String mId;
     private int mPriority;
+    private String mCode;
 
-    public Category(String name, String id, int priority) {
+    public Category(String name, String id, int priority, String code) {
         mName = name;
         mId = id;
         mPriority = priority;
+        mCode = code;
     }
 
     protected Category(Parcel in) {
         mName = in.readString();
         mId = in.readString();
         mPriority = in.readInt();
+        mCode = in.readString();
     }
 
     public static final Creator<Category> CREATOR = new Creator<Category>() {
@@ -61,6 +64,10 @@ public class Category implements Parcelable, Comparable<Category> {
         mPriority = priority;
     }
 
+    public String getCode() {
+        return mCode;
+    }
+
     @Override
     public int describeContents() {
         return 0;
@@ -71,8 +78,8 @@ public class Category implements Parcelable, Comparable<Category> {
         dest.writeString(mName);
         dest.writeString(mId);
         dest.writeInt(mPriority);
+        dest.writeString(mCode);
     }
-
 
     @Override
     public int compareTo(@NonNull Category o) {

--- a/majifix311/src/main/java/com/example/majifix311/ui/ProblemListActivity.java
+++ b/majifix311/src/main/java/com/example/majifix311/ui/ProblemListActivity.java
@@ -1,8 +1,22 @@
 package com.example.majifix311.ui;
 
+import android.os.Bundle;
+import android.os.PersistableBundle;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatActivity;
+
+import com.example.majifix311.R;
+
 /**
  * This activity shows a list of reported issues.
  */
 
-public class ProblemListActivity {
+public class ProblemListActivity extends AppCompatActivity {
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_list);
+    }
+
+    //TODO Move logic for making/responding-to network/db calls into here
 }

--- a/majifix311/src/main/java/com/example/majifix311/ui/ProblemListFragment.java
+++ b/majifix311/src/main/java/com/example/majifix311/ui/ProblemListFragment.java
@@ -1,0 +1,121 @@
+package com.example.majifix311.ui;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+import android.support.v4.content.LocalBroadcastManager;
+import android.support.v7.widget.DividerItemDecoration;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Toast;
+
+import com.example.majifix311.EventHandler;
+import com.example.majifix311.R;
+import com.example.majifix311.models.Category;
+import com.example.majifix311.models.Problem;
+import com.example.majifix311.models.Status;
+import com.example.majifix311.ui.adapters.ProblemListAdapter;
+
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.List;
+
+/**
+ * This is used to show a list of problems.
+ */
+
+public class ProblemListFragment extends Fragment implements ProblemListAdapter.OnItemClickListener {
+    private final static String PROBLEMS_INTENT = "problems";
+
+    private RecyclerView rvProblems;
+    private List<Problem> mProblems;
+    private ProblemListAdapter mAdapter;
+
+    // TODO: Use this method to send in problem list on fragment creation
+    public static ProblemListFragment getNewInstance(ArrayList<Problem> requests) {
+        Bundle args = new Bundle();
+        args.putParcelableArrayList(PROBLEMS_INTENT, requests);
+        ProblemListFragment instance = new ProblemListFragment();
+        instance.setArguments(args);
+        return instance;
+    }
+
+    // TODO: Move this to activity
+    private BroadcastReceiver mMyReportedProblemsReceived = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            if (intent.getBooleanExtra(EventHandler.IS_SUCCESS, false)) {
+                mProblems = intent.getParcelableArrayListExtra(EventHandler.PROBLEM_INTENT);
+                System.out.println("Problems Received! "+mProblems.size());
+                setupRecyclerView();
+            } else {
+                // TODO Implement error logic
+                Toast.makeText(getContext(), "Failure!", Toast.LENGTH_LONG).show();
+            }
+        }
+    };
+
+    @Nullable
+    @Override
+    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.fragment_problem_list, container, false);
+    }
+
+    @Override
+    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        rvProblems = (RecyclerView) view.findViewById(R.id.rv_problem_list);
+
+
+        // TODO Broadcast management should be handled by activity
+        LocalBroadcastManager.getInstance(getContext()).registerReceiver(mMyReportedProblemsReceived,
+                new IntentFilter(EventHandler.BROADCAST_MY_REPORTED_RECIEVED));
+
+        //sendMocks();
+
+        // mProblems = getArguments().getParcelableArrayList(PROBLEMS_INTENT);
+        // setupRecyclerView();
+    }
+
+//    private void sendMocks() {
+//        Problem.Builder builder = new Problem.Builder(null);
+//        Problem problem1 = builder.buildWithoutValidation(null, null, null,
+//                null, new Category("Puddle", "123", 3, "PU"),
+//                null, null, "Magnificent!", "TIC123",
+//                new Status(true, "In Progress", "#3498DB"), Calendar.getInstance(), null, null, null);
+//        Problem problem2 = builder.buildWithoutValidation(null, null, null,
+//                null, new Category("Shite Heap", "456", 3, "SH"),
+//                null, null, "Eew!", "TIC456",
+//                new Status(false, "Resolved", "#28B463"), Calendar.getInstance(), null, null, null);
+//        ArrayList<Problem> problems = new ArrayList<>(2);
+//        problems.add(problem1);
+//        problems.add(problem2);
+//
+//        EventHandler.sendMyReportedProblemsList(getContext(), problems);
+//    }
+
+    private void setupRecyclerView() {
+        mAdapter = new ProblemListAdapter(mProblems, this);
+        rvProblems.setAdapter(mAdapter);
+        rvProblems.setLayoutManager(
+                new LinearLayoutManager(getActivity(), LinearLayoutManager.VERTICAL, false));
+        rvProblems.addItemDecoration(
+                new DividerItemDecoration(getActivity(), DividerItemDecoration.VERTICAL));
+        rvProblems.setHasFixedSize(true); // layout dimens of each item will always be consistent
+        rvProblems.setNestedScrollingEnabled(true);
+    }
+
+    @Override
+    public void onItemClick(Problem problem) {
+        // TODO go to item detail on click
+        Toast.makeText(getContext(), "Problem "+problem.getTicketNumber()+" has been clicked", Toast.LENGTH_LONG).show();
+        getActivity().finish();
+    }
+}

--- a/majifix311/src/main/java/com/example/majifix311/ui/ReportProblemActivity.java
+++ b/majifix311/src/main/java/com/example/majifix311/ui/ReportProblemActivity.java
@@ -64,6 +64,19 @@ public class ReportProblemActivity extends FragmentActivity implements View.OnCl
 
     private Button mSubmitButton;
 
+    private BroadcastReceiver mPostResponse = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            // TODO replace with real logic
+            if (intent.getBooleanExtra(EventHandler.IS_SUCCESS, false)) {
+                Toast.makeText(getApplicationContext(), "Success!", Toast.LENGTH_LONG).show();
+                finish();
+            } else {
+                Toast.makeText(getApplicationContext(), "Failure!", Toast.LENGTH_LONG).show();
+            }
+        }
+    };
+
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         DatabaseHelper helper = new DatabaseHelper(this);
@@ -105,6 +118,12 @@ public class ReportProblemActivity extends FragmentActivity implements View.OnCl
         registerForPostUpdates();
     }
 
+    @Override
+    protected void onDestroy() {
+        LocalBroadcastManager.getInstance(this).unregisterReceiver(mPostResponse);
+        super.onDestroy();
+    }
+
     private void setupCategoryPicker() {
         // ensures keyboard stays closed on click
         mEtCategory.setInputType(InputType.TYPE_NULL);
@@ -122,7 +141,9 @@ public class ReportProblemActivity extends FragmentActivity implements View.OnCl
                 if (hasFocus) {
                     // close keyboard if open (for example, when pressing next)
                     InputMethodManager imm = (InputMethodManager)getSystemService(Context.INPUT_METHOD_SERVICE);
-                    imm.hideSoftInputFromWindow(mEtCategory.getWindowToken(), 0);
+                    if (imm != null) {
+                        imm.hideSoftInputFromWindow(mEtCategory.getWindowToken(), 0);
+                    }
 
                     // start dialog
                     createCategoryPickerDialog(mCategories);
@@ -145,18 +166,8 @@ public class ReportProblemActivity extends FragmentActivity implements View.OnCl
     }
 
     private void registerForPostUpdates() {
-        LocalBroadcastManager.getInstance(this).registerReceiver(new BroadcastReceiver() {
-            @Override
-            public void onReceive(Context context, Intent intent) {
-                // TODO replace with real logic
-                if (intent.getBooleanExtra(EventHandler.IS_SUCCESS, false)) {
-                    Toast.makeText(getApplicationContext(), "Success!", Toast.LENGTH_LONG).show();
-                    finish();
-                } else {
-                    Toast.makeText(getApplicationContext(), "Failure!", Toast.LENGTH_LONG).show();
-                }
-            }
-        }, new IntentFilter(EventHandler.BROADCAST_REPORT_RECIEVED));
+        LocalBroadcastManager.getInstance(this).registerReceiver(mPostResponse,
+                new IntentFilter(EventHandler.BROADCAST_REPORT_RECIEVED));
     }
 
     private void submit() {

--- a/majifix311/src/main/java/com/example/majifix311/ui/adapters/ProblemListAdapter.java
+++ b/majifix311/src/main/java/com/example/majifix311/ui/adapters/ProblemListAdapter.java
@@ -1,0 +1,104 @@
+package com.example.majifix311.ui.adapters;
+
+import android.app.Application;
+import android.graphics.Color;
+import android.support.v4.content.ContextCompat;
+import android.support.v4.graphics.drawable.DrawableCompat;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.AdapterView;
+import android.widget.TextView;
+
+import com.example.majifix311.R;
+import com.example.majifix311.models.Problem;
+import com.example.majifix311.models.Status;
+import com.example.majifix311.utils.DateUtils;
+
+import java.util.List;
+
+public class ProblemListAdapter extends  RecyclerView.Adapter<RecyclerView.ViewHolder> {
+
+    private final List<Problem> mProblems;
+    private final OnItemClickListener mClickListener;
+
+    public ProblemListAdapter(List<Problem> problems,
+                              OnItemClickListener onItemClickListener) {
+
+        mProblems = problems;
+        mClickListener = onItemClickListener;
+    }
+
+    @Override
+    public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+        LayoutInflater inflater = LayoutInflater.from(parent.getContext());
+        View view = inflater.inflate(R.layout.item_problem_list, parent, false);
+        return new ProblemViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(RecyclerView.ViewHolder holder, int position) {
+        Problem problem = this.mProblems.get(position);
+        ProblemViewHolder srViewHolder = (ProblemViewHolder) holder;
+
+        // to the left of each row is a circle, colored by status, with the category code
+        srViewHolder.tvCategoryIcon.setText(problem.getCategory().getCode());
+        int categoryIconColor;
+        try {
+            categoryIconColor = Color.parseColor(problem.getStatus().getColor());
+        } catch (IllegalArgumentException e) {
+            categoryIconColor = ContextCompat.getColor(srViewHolder.cardView.getContext(),
+                    problem.getStatus().isOpen() ? R.color.open : R.color.resolved);
+        }
+        DrawableCompat.setTint(srViewHolder.tvCategoryIcon.getBackground(), categoryIconColor);
+
+        // the right text contains other relevant information
+        srViewHolder.tvTitle.setText(problem.getCategory().getName());
+        srViewHolder.tvTicketID.setText(problem.getTicketNumber());
+        srViewHolder.tvDescription.setText(problem.getDescription());
+        srViewHolder.tvDateCreated.setText(DateUtils.formatForDisplay(problem.getCreatedAt()));
+
+        // hook up on item click listener
+        srViewHolder.bind(problem, mClickListener);
+    }
+
+    @Override
+    public int getItemCount() {
+        return mProblems.size();
+    }
+
+    private static class ProblemViewHolder extends RecyclerView.ViewHolder {
+        View cardView;
+        TextView tvCategoryIcon;
+        TextView tvTitle;
+        TextView tvDescription;
+        TextView tvDateCreated;
+        TextView tvTicketID;
+
+        ProblemViewHolder(View itemView) {
+            super(itemView);
+            cardView = itemView;
+            tvCategoryIcon = (TextView) itemView.findViewById(R.id.tv_categoryIcon);
+            tvTitle = (TextView) itemView.findViewById(R.id.tv_problemTitle);
+            tvTicketID = (TextView) itemView.findViewById(R.id.tv_problemTicketID);
+            tvDescription = (TextView) itemView.findViewById(R.id.tv_problemDescription);
+            tvDateCreated = (TextView) itemView.findViewById(R.id.tv_problemDate);
+        }
+
+        void bind(final Problem problem, final OnItemClickListener listener) {
+            cardView.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    if (listener != null) {
+                        listener.onItemClick(problem);
+                    }
+                }
+            });
+        }
+    }
+
+    public interface OnItemClickListener {
+        void onItemClick(Problem problem);
+    }
+}

--- a/majifix311/src/main/java/com/example/majifix311/ui/adapters/ProblemListAdapter.java
+++ b/majifix311/src/main/java/com/example/majifix311/ui/adapters/ProblemListAdapter.java
@@ -47,7 +47,7 @@ public class ProblemListAdapter extends  RecyclerView.Adapter<RecyclerView.ViewH
         int categoryIconColor;
         try {
             categoryIconColor = Color.parseColor(problem.getStatus().getColor());
-        } catch (IllegalArgumentException e) {
+        } catch (Exception e) {
             categoryIconColor = ContextCompat.getColor(srViewHolder.cardView.getContext(),
                     problem.getStatus().isOpen() ? R.color.open : R.color.resolved);
         }
@@ -68,7 +68,7 @@ public class ProblemListAdapter extends  RecyclerView.Adapter<RecyclerView.ViewH
         return mProblems.size();
     }
 
-    private static class ProblemViewHolder extends RecyclerView.ViewHolder {
+    static class ProblemViewHolder extends RecyclerView.ViewHolder {
         View cardView;
         TextView tvCategoryIcon;
         TextView tvTitle;

--- a/majifix311/src/main/java/com/example/majifix311/utils/DateUtils.java
+++ b/majifix311/src/main/java/com/example/majifix311/utils/DateUtils.java
@@ -1,9 +1,12 @@
 package com.example.majifix311.utils;
 
+import android.support.annotation.NonNull;
+
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.Locale;
 
 /**
  * This is used to manage date formats.
@@ -12,6 +15,9 @@ import java.util.Date;
 public class DateUtils {
     private static SimpleDateFormat sdfMajiFixString =
             new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+
+    private static SimpleDateFormat sdfDisplayShort =
+            new SimpleDateFormat("MMM dd HH:mm");
 
     public static Calendar getCalendarFromMajiFixApiString(String fromServer) {
         if (fromServer == null) {
@@ -34,5 +40,9 @@ public class DateUtils {
         Calendar calendar = Calendar.getInstance();
         calendar.setTime(new Date(fromDb));
         return calendar;
+    }
+
+    public static String formatForDisplay(@NonNull Calendar date) {
+        return sdfDisplayShort.format(date.getTime());
     }
 }

--- a/majifix311/src/main/res/drawable/shape_list_item_resolved.xml
+++ b/majifix311/src/main/res/drawable/shape_list_item_resolved.xml
@@ -1,0 +1,16 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:innerRadius="0dp"
+    android:thicknessRatio="2"
+    android:shape="ring"
+    android:useLevel="false">
+
+    <solid android:color="@color/resolved" />
+
+    <size
+        android:height="48dp"
+        android:width="48dp" />
+
+    <stroke
+        android:width="1dp"
+        android:color="@color/separator" />
+</shape>

--- a/majifix311/src/main/res/layout/activity_list.xml
+++ b/majifix311/src/main/res/layout/activity_list.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<fragment xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/fragment"
+    android:name="com.example.majifix311.ui.ProblemListFragment"
+    android:layout_height="match_parent"
+    android:layout_width="match_parent"
+    app:layout_behavior="@string/appbar_scrolling_view_behavior"
+    tools:layout="@layout/fragment_problem_list" />

--- a/majifix311/src/main/res/layout/fragment_problem_list.xml
+++ b/majifix311/src/main/res/layout/fragment_problem_list.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/rv_problem_list"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</android.support.constraint.ConstraintLayout>

--- a/majifix311/src/main/res/layout/item_problem_list.xml
+++ b/majifix311/src/main/res/layout/item_problem_list.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.v7.widget.CardView
+    android:id="@+id/crd_TicketItem"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    app:cardCornerRadius="0dp"
+    app:cardElevation="0dp"
+    android:clickable="true"
+    android:focusable="true"
+    android:foreground="?android:attr/selectableItemBackground">
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_weight="3"
+        android:padding="16dp"
+        android:layout_gravity="center_vertical">
+
+        <TextView
+            android:id="@+id/tv_categoryIcon"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:contentDescription=""
+            android:background="@drawable/shape_list_item_resolved"
+            android:layout_alignParentStart="true"
+            android:layout_alignParentLeft="true"
+            android:layout_centerVertical="true"
+            android:textColor="@android:color/white"
+            android:textSize="18sp"
+            android:gravity="center"
+            android:textAlignment="center" />
+
+
+        <TextView
+            android:id="@+id/tv_problemDate"
+            style="@style/ItemCardTextView"
+            android:layout_width="fill_parent"
+            android:gravity="end"
+            android:textAlignment="viewEnd"
+            android:layout_alignParentTop="true"
+            android:layout_alignParentEnd="true"
+            android:layout_alignParentRight="true" />
+
+
+        <LinearLayout
+            android:id="@+id/ll_leftLayout"
+            android:layout_toEndOf="@id/tv_categoryIcon"
+            android:layout_toRightOf="@id/tv_categoryIcon"
+            android:layout_centerVertical="true"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:layout_marginStart="16dp"
+            android:layout_marginLeft="16dp">
+
+            <TextView
+                android:id="@+id/tv_problemTitle"
+                style="@style/ItemCardTextView.Medium"
+                android:textColor="@android:color/black"/>
+
+            <TextView
+                android:id="@+id/tv_problemTicketID"
+                style="@style/ItemCardTextView"
+                android:paddingTop="8dp"
+                android:maxLines="1"
+                android:ellipsize="end"
+                android:textColor="@android:color/black"/>
+
+            <TextView
+                android:id="@+id/tv_problemDescription"
+                style="@style/ItemCardTextView"
+                android:paddingTop="8dp"
+                android:maxLines="1"
+                android:ellipsize="end"/>
+        </LinearLayout>
+    </RelativeLayout>
+
+</android.support.v7.widget.CardView>

--- a/majifix311/src/main/res/values/colors.xml
+++ b/majifix311/src/main/res/values/colors.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <color name="accent">#3A8BCA</color>
+
     <color name="error">#cc0000</color>
-    <color name="separator">#aaaaaa</color>
+    <color name="separator">#999999</color>
+
+    <color name="open">@color/accent</color>
+    <color name="resolved">#3CCA68</color>
+
 </resources>

--- a/majifix311/src/main/res/values/styles.xml
+++ b/majifix311/src/main/res/values/styles.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="ItemCardTextView">
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:padding">0dp</item>
+        <item name="android:layout_margin">0dp</item>
+        <item name="android:textAppearance">?android:attr/textAppearanceSmall</item>
+    </style>
+
+    <style name="ItemCardTextView.Medium">
+        <item name="android:textAppearance">?android:attr/textAppearanceMedium</item>
+    </style>
+</resources>

--- a/majifix311/src/test/java/com/example/majifix311/CategoryTest.java
+++ b/majifix311/src/test/java/com/example/majifix311/CategoryTest.java
@@ -24,10 +24,11 @@ public class CategoryTest {
     private String mockName = "colors";
     private String mockId = "000000";
     private int mockPriority = 5;
+    private String mockCode = "RGB";
 
     @Test
     public void category_isParcelable() {
-        Category category = new Category(mockName, mockId, mockPriority);
+        Category category = new Category(mockName, mockId, mockPriority, mockCode);
         assertMatchesMock(category);
 
         Parcel parcel = Parcel.obtain();
@@ -41,9 +42,9 @@ public class CategoryTest {
     @Test
     public void category_isSortedByPriority() {
         List<Category> categories = new ArrayList<>(3);
-        categories.add(new Category(mockName, "0", 3));
-        categories.add(new Category(mockName, "1", 5));
-        categories.add(new Category(mockName, "2", 1));
+        categories.add(new Category(mockName, "0", 3, mockCode));
+        categories.add(new Category(mockName, "1", 5, mockCode));
+        categories.add(new Category(mockName, "2", 1, mockCode));
 
         assertEquals("0", categories.get(0).getId());
         assertEquals("1", categories.get(1).getId());
@@ -60,5 +61,6 @@ public class CategoryTest {
         assertEquals(mockName, category.getName());
         assertEquals(mockId, category.getId());
         assertEquals(mockPriority, category.getPriority());
+        assertEquals(mockCode, category.getCode());
     }
 }

--- a/majifix311/src/test/java/com/example/majifix311/DatabaseHelperTest.java
+++ b/majifix311/src/test/java/com/example/majifix311/DatabaseHelperTest.java
@@ -43,8 +43,8 @@ public class DatabaseHelperTest {
     @Test
     public void canWriteCategoriesToDatabase() {
         List<ApiService> mockServices = new ArrayList<>(2);
-        ApiService mockService1 = new ApiService("1","cat1", 1);
-        ApiService mockService2 = new ApiService("2","cat2", 2);
+        ApiService mockService1 = new ApiService("1","cat1", 1, "one");
+        ApiService mockService2 = new ApiService("2","cat2", 2, "two");
         mockServices.add(mockService1);
         mockServices.add(mockService2);
 
@@ -58,9 +58,11 @@ public class DatabaseHelperTest {
         assertEquals("cat2", mCategoriesResult.get(0).getName());
         assertEquals("2", mCategoriesResult.get(0).getId());
         assertEquals(2, mCategoriesResult.get(0).getPriority());
+        assertEquals("two", mCategoriesResult.get(0).getCode());
         assertEquals("cat1", mCategoriesResult.get(1).getName());
         assertEquals("1", mCategoriesResult.get(1).getId());
         assertEquals(1, mCategoriesResult.get(1).getPriority());
+        assertEquals("one", mCategoriesResult.get(1).getCode());
     }
 
     @Test

--- a/majifix311/src/test/java/com/example/majifix311/DateUtilTest.java
+++ b/majifix311/src/test/java/com/example/majifix311/DateUtilTest.java
@@ -13,6 +13,7 @@ import java.util.Locale;
 
 import static java.util.Locale.*;
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.fail;
 
 /**
  * This is used to test string to date object conversions.
@@ -39,6 +40,15 @@ public class DateUtilTest {
         Calendar fromMills = DateUtils.getCalendarFromDbMills(mills);
 
         testCalendar(fromMills, 2015, Calendar.OCTOBER, 22, 9, 3, 46);
+    }
+
+    @Test
+    public void testDisplayFormat() {
+        String fromServer = "2015-10-22T09:03:46.845Z";
+        Calendar calendar = DateUtils.getCalendarFromMajiFixApiString(fromServer);
+
+        String forDisplay = DateUtils.formatForDisplay(calendar);
+        assertEquals("Oct 22 09:03", forDisplay);
     }
 
     public static void testCalendar(Calendar cal, int year, int month, int date,

--- a/majifix311/src/test/java/com/example/majifix311/Mocks.java
+++ b/majifix311/src/test/java/com/example/majifix311/Mocks.java
@@ -15,6 +15,7 @@ class Mocks {
     static String mockAccount = "A123";
     static String mockCategoryName = "Puddle";
     static String mockCategoryId = "5968b64148dfc224bb47748d";
+    static String mockCategoryCode = "PU";
     static double latitude = 1.1d;
     static double longitude = 2.2d;
     static String mockAddress = "55 Marimbo St";
@@ -36,7 +37,7 @@ class Mocks {
             "    \"service\": {\n" +
             "        \"jurisdiction\": {},\n" +
             "        \"group\": {},\n" +
-            "        \"code\": \"LW\",\n" +
+            "        \"code\": \""+mockCategoryCode+"\",\n" +
             "        \"name\": \""+mockCategoryName+"\",\n" +
             "        \"description\": \"Lack of Water related service request(issue)\",\n" +
             "        \"color\": \"#C62828\",\n" +

--- a/majifix311/src/test/java/com/example/majifix311/ProblemListActivityTest.java
+++ b/majifix311/src/test/java/com/example/majifix311/ProblemListActivityTest.java
@@ -1,0 +1,103 @@
+package com.example.majifix311;
+
+import android.app.Application;
+import android.graphics.Color;
+import android.support.v7.widget.RecyclerView;
+import android.view.View;
+import android.widget.TextView;
+
+import com.example.majifix311.api.ApiModelConverter;
+import com.example.majifix311.models.Category;
+import com.example.majifix311.models.Problem;
+import com.example.majifix311.models.Status;
+import com.example.majifix311.ui.ProblemListActivity;
+import com.example.majifix311.ui.ProblemListFragment;
+import com.example.majifix311.utils.DateUtils;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+import java.util.ArrayList;
+import java.util.Calendar;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
+
+/**
+ * This tests the ProblemListActivity.
+ */
+
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class)
+public class ProblemListActivityTest {
+    private ProblemListActivity mActivity;
+    private ArrayList<Problem> mockProblems;
+    private RecyclerView mRecyclerView;
+
+    @Before
+    public void startActivity() {
+        mActivity = Robolectric.setupActivity(ProblemListActivity.class);
+        mRecyclerView = (RecyclerView) mActivity.findViewById(R.id.rv_problem_list);
+    }
+
+    @Test
+    public void fragmentStarted() {
+        assertNotNull(mRecyclerView);
+    }
+
+    @Test
+    public void listIsPopulatedWithProblems() {
+        sendMocks();
+
+        RecyclerView.ViewHolder firstRow = mRecyclerView.findViewHolderForAdapterPosition(0);
+        RecyclerView.ViewHolder secondRow = mRecyclerView.findViewHolderForAdapterPosition(1);
+        RecyclerView.ViewHolder thirdRow = mRecyclerView.findViewHolderForAdapterPosition(2);
+        assertNotNull(firstRow);
+        assertNotNull(secondRow);
+        assertNotNull(thirdRow);
+
+        assertListViewMatchesProblem(mockProblems.get(0), firstRow.itemView);
+        assertListViewMatchesProblem(mockProblems.get(1), secondRow.itemView);
+        assertListViewMatchesProblem(mockProblems.get(2), thirdRow.itemView);
+    }
+
+    private void assertListViewMatchesProblem(Problem problem, View itemView) {
+        TextView tvCategoryIcon = (TextView) itemView.findViewById(R.id.tv_categoryIcon);
+        TextView tvTitle = (TextView) itemView.findViewById(R.id.tv_problemTitle);
+        TextView tvTicketID = (TextView) itemView.findViewById(R.id.tv_problemTicketID);
+        TextView tvDescription = (TextView) itemView.findViewById(R.id.tv_problemDescription);
+        TextView tvDateCreated = (TextView) itemView.findViewById(R.id.tv_problemDate);
+
+        assertEquals("Left circle should contain category code.", problem.getCategory().getCode(), tvCategoryIcon.getText());
+//        assertEquals("Left circle background tint should match status", Color.parseColor(problem.getStatus().getColor(), tvCategoryIcon.getBackground().getColorFilter())); //TODO test tint
+        assertEquals("Title should be category name.", problem.getCategory().getName(), tvTitle.getText());
+        assertEquals("Ticket number should be correctly displayed", problem.getTicketNumber(), tvTicketID.getText());
+        assertEquals("Description should be properly displayed", problem.getDescription(), tvDescription.getText());
+        assertEquals("Date created should be properly formatted", DateUtils.formatForDisplay(problem.getCreatedAt()), tvDateCreated.getText());
+    }
+
+    private void sendMocks() {
+        Problem.Builder builder = new Problem.Builder(null);
+        Problem fullProblem = ApiModelConverter.convert(ProblemTest.buildMockServerResponse());
+        Problem partialProblem1 = builder.buildWithoutValidation(null, null, null,
+                null, new Category("Puddle", "123", 3, "PU"),
+                null, null, "Magnificent!", "TIC123",
+                new Status(true, "In Progress", "#3498DB"), Calendar.getInstance(), null, null, null);
+        Problem partialProblem2 = builder.buildWithoutValidation(null, null, null,
+                null, new Category("Shite Heap", "456", 3, "SH"),
+                null, null, "Eew!", "TIC456",
+                new Status(false, "Resolved", "#28B463"), Calendar.getInstance(), null, null, null);
+        mockProblems = new ArrayList<>(2);
+        mockProblems.add(fullProblem);
+        mockProblems.add(partialProblem1);
+        mockProblems.add(partialProblem2);
+
+        EventHandler.sendMyReportedProblemsList(RuntimeEnvironment.application, mockProblems);
+    }
+
+}

--- a/majifix311/src/test/java/com/example/majifix311/ProblemTest.java
+++ b/majifix311/src/test/java/com/example/majifix311/ProblemTest.java
@@ -35,7 +35,8 @@ import static junit.framework.Assert.assertTrue;
 @RunWith(RobolectricTestRunner.class)
 @Config(constants = BuildConfig.class)
 public class ProblemTest implements Problem.Builder.InvalidCallbacks {
-    private static Category mockCategory = new Category(mockCategoryName, mockCategoryId, 0);
+    private static Category mockCategory = new Category(
+            mockCategoryName, mockCategoryId, 0, mockCategoryCode);
     private static Location mockLocation = new Location("");
     private int problemCount;
 
@@ -182,6 +183,7 @@ public class ProblemTest implements Problem.Builder.InvalidCallbacks {
         assertEquals("Category name should be correct", mockCategoryName, problem.getCategory().getName());
         assertEquals("Category id should be correct", mockCategoryId, problem.getCategory().getId());
         assertEquals("Category priority should be correct", 0, problem.getCategory().getPriority());
+        assertEquals("Category code should be correct", mockCategoryCode, problem.getCategory().getCode());
         assertEquals("Latitude should be correct", latitude, problem.getLocation().getLatitude());
         assertEquals("Longitude should be correct", longitude, problem.getLocation().getLongitude());
         assertEquals("Address should be correct", mockAddress, problem.getAddress());

--- a/majifix311/src/test/java/com/example/majifix311/ReportProblemActivityTest.java
+++ b/majifix311/src/test/java/com/example/majifix311/ReportProblemActivityTest.java
@@ -51,13 +51,6 @@ public class ReportProblemActivityTest {
     private String mockAddress = "55 Marimbo St";
     private String mockDescription = "Horrible horrible horrible!!";
 
-    private class WorkaroundReportProblemActivity extends ReportProblemActivity {
-        @Override
-        public void setContentView(View view) {
-            super.setContentView(view);
-        }
-    }
-
     @Before
     public void startActivity() {
         mActivity = Robolectric.setupActivity(ReportProblemActivity.class);

--- a/majifix311/src/test/java/com/example/majifix311/ReportProblemActivityTest.java
+++ b/majifix311/src/test/java/com/example/majifix311/ReportProblemActivityTest.java
@@ -21,6 +21,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
+import static com.example.majifix311.Mocks.mockCategoryCode;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertNull;
@@ -45,7 +46,7 @@ public class ReportProblemActivityTest {
 
     private String mockName = "Test User";
     private String mockNumber = "123456789";
-    private Category mockCategory = new Category("Puddle","5968b64148dfc224bb47748d", 0);
+    private Category mockCategory = new Category("Puddle","5968b64148dfc224bb47748d", 0, mockCategoryCode);
     private Location mockLocation = new Location("");
     private String mockAddress = "55 Marimbo St";
     private String mockDescription = "Horrible horrible horrible!!";


### PR DESCRIPTION
This adds a fragment, which will respond to a broadcast and display a list of issues.

Ideally: the broadcast should be handled by the activity, as the activity will probably be in charge of displaying error messages, empty list messages, and organizing the problems into different tabs (for example: an open and closed tab). Each tab would be a seperate list fragment. There are todos marking the need for this change.

I have left commented out code that will display too mock issues, so that developers can see what things "should" look like.

NOTE: Currently, "app" module tests are failing.