### PR TITLE
Feature/add attachment to form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,7 @@
 *.iml
 .gradle
 /local.properties
-/.idea/workspace.xml
-/.idea/libraries
-/.idea/misc.xml
-/.idea/modules.xml
+/.idea/*
 .DS_Store
 /build
 /captures

--- a/majifix311/src/main/AndroidManifest.xml
+++ b/majifix311/src/main/AndroidManifest.xml
@@ -3,13 +3,28 @@
     package="com.example.majifix311">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+
+    <uses-feature android:name="android.hardware.camera"
+                  android:required="false" />
 
     <application
         android:allowBackup="true"
         android:label="@string/app_name"
         android:theme="@style/Theme.AppCompat"
         android:supportsRtl="true">
+
         <service android:name=".api.ReportService" />
+
+        <provider
+            android:authorities="com.example.majifix311.fileprovider"
+            android:name="android.support.v4.content.FileProvider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
 
         <activity
             android:name=".ui.ReportProblemActivity"

--- a/majifix311/src/main/AndroidManifest.xml
+++ b/majifix311/src/main/AndroidManifest.xml
@@ -5,7 +5,10 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
+    <!-- Needed only if your app targets Android 5.0 (API level 21) or higher. -->
+    <uses-feature android:name="android.hardware.location.gps" />
     <uses-feature android:name="android.hardware.camera"
                   android:required="false" />
 

--- a/majifix311/src/main/java/com/example/majifix311/models/Problem.java
+++ b/majifix311/src/main/java/com/example/majifix311/models/Problem.java
@@ -39,7 +39,8 @@ public class Problem implements Parcelable {
 //    private List<Comment> mComments; //TODO Implement
 
     private Problem(String username, String phone, String email, String account,
-                    Category category, Location location, String address, String description) {
+                    Category category, Location location, String address, String description,
+                    List<Attachment> attachments) {
         mReporter = new Reporter();
         mReporter.setName(username);
         mReporter.setPhone(phone);
@@ -50,20 +51,21 @@ public class Problem implements Parcelable {
         mLocation = location;
         mAddress = address;
         mDescription = description;
+
+        mAttachments = attachments;
     }
 
     private Problem(String username, String phone, String email, String account,
                     Category category, Location location, String address, String description,
                     String ticketNumber, Status status, Calendar createdAt, Calendar updatedAt,
                     Calendar resolvedAt, List<Attachment> attachments) {
-        this(username, phone, email, account, category, location, address, description);
+        this(username, phone, email, account, category, location, address, description, attachments);
 
         mTicketNumber = ticketNumber;
         mStatus = status;
         mCreatedAt = createdAt;
         mUpdatedAt = updatedAt;
         mResolvedAt = resolvedAt;
-        mAttachments = attachments;
     }
 
     private Problem(Parcel in) {
@@ -210,6 +212,7 @@ public class Problem implements Parcelable {
         Location tempLocation;
         String tempAddress;
         String tempDescription;
+        List<Attachment> tempAttachments;
 
         public Builder(InvalidCallbacks listener) {
             mListener = listener;
@@ -276,12 +279,19 @@ public class Problem implements Parcelable {
             tempDescription = description.trim();
         }
 
+        public void addAttachment(Attachment attachment) {
+            if (tempAttachments == null) {
+                tempAttachments = new ArrayList<>();
+            }
+            tempAttachments.add(attachment);
+        }
+
         public Problem build() {
             //TODO add back the validation when location is added
 //            return new Problem(tempUsername, tempPhone, tempCategory,
 //                    tempLocation, tempAddress, tempDescription);
             return validate() ? new Problem(tempUsername, tempPhone, tempEmail, tempAccount,
-                    tempCategory, tempLocation, tempAddress, tempDescription) : null;
+                    tempCategory, tempLocation, tempAddress, tempDescription, tempAttachments) : null;
         }
 
         public Problem buildWithoutValidation(String username, String phone, String email,

--- a/majifix311/src/main/java/com/example/majifix311/models/Problem.java
+++ b/majifix311/src/main/java/com/example/majifix311/models/Problem.java
@@ -287,7 +287,6 @@ public class Problem implements Parcelable {
         }
 
         public Problem build() {
-            //TODO add back the validation when location is added
 //            return new Problem(tempUsername, tempPhone, tempCategory,
 //                    tempLocation, tempAddress, tempDescription);
             return validate() ? new Problem(tempUsername, tempPhone, tempEmail, tempAccount,

--- a/majifix311/src/main/java/com/example/majifix311/ui/ReportProblemActivity.java
+++ b/majifix311/src/main/java/com/example/majifix311/ui/ReportProblemActivity.java
@@ -4,8 +4,11 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.pm.PackageManager;
+import android.graphics.Bitmap;
 import android.location.Location;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.design.widget.TextInputLayout;
 import android.support.v4.app.FragmentActivity;
@@ -21,16 +24,20 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import com.example.majifix311.EventHandler;
+import com.example.majifix311.models.Attachment;
 import com.example.majifix311.models.Category;
 import com.example.majifix311.models.Problem;
 import com.example.majifix311.R;
 import com.example.majifix311.api.ReportService;
 import com.example.majifix311.db.DatabaseHelper;
+import com.example.majifix311.utils.AttachmentUtils;
 import com.example.majifix311.utils.EmptyErrorTrigger;
 
 import java.util.List;
 
 import io.reactivex.functions.Consumer;
+
+import static android.view.View.GONE;
 
 /**
  * This activity is for submitting problems to a municipal company that uses the majifix system.
@@ -57,10 +64,11 @@ public class ReportProblemActivity extends FragmentActivity implements View.OnCl
     private EditText mEtAddress;
     private EditText mEtDescription;
 
-    private LinearLayout mLlLocation;
     private ImageView mIvLocation;
     private TextView mTvLocationError;
     private LinearLayout mLlPhoto;
+    private ImageView mIvPhoto;
+    private String mAttachmentUrl;
 
     private Button mSubmitButton;
 
@@ -96,10 +104,10 @@ public class ReportProblemActivity extends FragmentActivity implements View.OnCl
         mEtCategory = (EditText) findViewById(R.id.et_category);
         mEtAddress = (EditText) findViewById(R.id.et_address);
         mEtDescription = (EditText) findViewById(R.id.et_description);
-        mLlLocation = (LinearLayout) findViewById(R.id.ll_add_location);
         mIvLocation = (ImageView) findViewById(R.id.iv_location);
         mTvLocationError = (TextView) findViewById(R.id.tv_location_error);
         mLlPhoto = (LinearLayout) findViewById(R.id.ll_add_photo);
+        mIvPhoto = (ImageView) findViewById(R.id.iv_add_photo);
 
         // for required fields: watch for text changes, and if empty, display error
         mEtName.addTextChangedListener(new EmptyErrorTrigger(mTilName));
@@ -112,6 +120,7 @@ public class ReportProblemActivity extends FragmentActivity implements View.OnCl
         mSubmitButton = (Button) findViewById(R.id.btn_submit);
         mSubmitButton.setOnClickListener(this);
         setupCategoryPicker();
+        setupPhotoListener();
 
         // initialize problem builder
         mBuilder = new Problem.Builder(this);
@@ -122,6 +131,30 @@ public class ReportProblemActivity extends FragmentActivity implements View.OnCl
     protected void onDestroy() {
         LocalBroadcastManager.getInstance(this).unregisterReceiver(mPostResponse);
         super.onDestroy();
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+
+        // Intent was fired to capture photo. Display thumbnail in given imageview.
+        boolean photoCaptureSuccess = AttachmentUtils.setThumbnailFromActivityResult(
+                mIvPhoto, mAttachmentUrl, requestCode, resultCode, data);
+        if (!photoCaptureSuccess) {
+            // If photo cannot be found, reset state
+            mAttachmentUrl = null;
+        } else {
+            //TODO mBuilder.addAttachment()
+        }
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+
+        // Check if this is a storage permission. If so, attempt to start camera.
+        mAttachmentUrl = AttachmentUtils.onRequestPermissionResult(
+                this, requestCode, permissions, grantResults);
     }
 
     private void setupCategoryPicker() {
@@ -150,6 +183,22 @@ public class ReportProblemActivity extends FragmentActivity implements View.OnCl
                 }
             }
         });
+    }
+
+    private void setupPhotoListener() {
+        // Check if phone is equipped with camera
+        if (this.getPackageManager().hasSystemFeature(PackageManager.FEATURE_CAMERA)) {
+            // If so, trigger camera on click. Picture will be returned in onActivityResult
+            mLlPhoto.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    mAttachmentUrl = AttachmentUtils.dipatchTakePictureIntent(ReportProblemActivity.this);
+                }
+            });
+        } else {
+            // If not, hide camera icon and label
+            mLlPhoto.setVisibility(GONE);
+        }
     }
 
     private void createCategoryPickerDialog(Category[] categories) {

--- a/majifix311/src/main/java/com/example/majifix311/ui/ReportProblemActivity.java
+++ b/majifix311/src/main/java/com/example/majifix311/ui/ReportProblemActivity.java
@@ -63,9 +63,6 @@ public class ReportProblemActivity extends FragmentActivity implements View.OnCl
     private ImageView mIvLocation;
     private TextView mTvLocationError;
     private AttachmentButton mAbPhoto;
-    //private LinearLayout mLlPhoto;
-    //private ImageView mIvPhoto;
-    //private String mAttachmentUrl;
 
     private Button mSubmitButton;
 
@@ -104,8 +101,6 @@ public class ReportProblemActivity extends FragmentActivity implements View.OnCl
         mIvLocation = (ImageView) findViewById(R.id.iv_location);
         mTvLocationError = (TextView) findViewById(R.id.tv_location_error);
         mAbPhoto = (AttachmentButton) findViewById(R.id.ab_add_photo);
-        //mLlPhoto = (LinearLayout) findViewById(R.id.ll_add_photo);
-        //mIvPhoto = (ImageView) findViewById(R.id.iv_add_photo);
 
         // for required fields: watch for text changes, and if empty, display error
         mEtName.addTextChangedListener(new EmptyErrorTrigger(mTilName));
@@ -118,7 +113,6 @@ public class ReportProblemActivity extends FragmentActivity implements View.OnCl
         mSubmitButton = (Button) findViewById(R.id.btn_submit);
         mSubmitButton.setOnClickListener(this);
         setupCategoryPicker();
-        setupPhotoListener();
 
         // initialize problem builder
         mBuilder = new Problem.Builder(this);
@@ -151,9 +145,6 @@ public class ReportProblemActivity extends FragmentActivity implements View.OnCl
 
         // Attachment button will handle photo permissions requests
         mAbPhoto.onRequestPermissionResult(requestCode, permissions, grantResults);
-        // Check if this is a storage permission. If so, attempt to start camera.
-//        mAttachmentUrl = AttachmentUtils.onRequestPermissionResult(
-//                this, requestCode, permissions, grantResults);
     }
 
     private void setupCategoryPicker() {
@@ -182,25 +173,6 @@ public class ReportProblemActivity extends FragmentActivity implements View.OnCl
                 }
             }
         });
-    }
-
-    private void setupPhotoListener() {
-       // AttachmentUtils.setupAddAttachmentButton(this, mLlPhoto);
-
-        // Check if phone is equipped with camera
-//        if (this.getPackageManager().hasSystemFeature(PackageManager.FEATURE_CAMERA)) {
-//            // If so, trigger camera on click
-//            mLlPhoto.setOnClickListener(new View.OnClickListener() {
-//                @Override
-//                public void onClick(View v) {
-//                    // mAttachmentUrl will be used to retrieve the file in displayOnActivityResult
-//                    mAttachmentUrl = AttachmentUtils.dipatchTakePictureIntent(ReportProblemActivity.this);
-//                }
-//            });
-//        } else {
-//            // If not, hide camera icon and label
-//            mLlPhoto.setVisibility(GONE);
-//        }
     }
 
     private void createCategoryPickerDialog(Category[] categories) {

--- a/majifix311/src/main/java/com/example/majifix311/ui/ReportProblemActivity.java
+++ b/majifix311/src/main/java/com/example/majifix311/ui/ReportProblemActivity.java
@@ -144,7 +144,8 @@ public class ReportProblemActivity extends FragmentActivity implements View.OnCl
             // If photo cannot be found, reset state
             mAttachmentUrl = null;
         } else {
-            //TODO mBuilder.addAttachment()
+            Attachment attachment = AttachmentUtils.getPicAsAttachment(mAttachmentUrl);
+            mBuilder.addAttachment(attachment);
         }
     }
 
@@ -188,10 +189,11 @@ public class ReportProblemActivity extends FragmentActivity implements View.OnCl
     private void setupPhotoListener() {
         // Check if phone is equipped with camera
         if (this.getPackageManager().hasSystemFeature(PackageManager.FEATURE_CAMERA)) {
-            // If so, trigger camera on click. Picture will be returned in onActivityResult
+            // If so, trigger camera on click
             mLlPhoto.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
+                    // mAttachmentUrl will be used to retrieve the file in onActivityResult
                     mAttachmentUrl = AttachmentUtils.dipatchTakePictureIntent(ReportProblemActivity.this);
                 }
             });

--- a/majifix311/src/main/java/com/example/majifix311/ui/ReportProblemActivity.java
+++ b/majifix311/src/main/java/com/example/majifix311/ui/ReportProblemActivity.java
@@ -4,8 +4,6 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.content.pm.PackageManager;
-import android.graphics.Bitmap;
 import android.location.Location;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -19,7 +17,6 @@ import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ImageView;
-import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -30,14 +27,13 @@ import com.example.majifix311.models.Problem;
 import com.example.majifix311.R;
 import com.example.majifix311.api.ReportService;
 import com.example.majifix311.db.DatabaseHelper;
+import com.example.majifix311.ui.views.AttachmentButton;
 import com.example.majifix311.utils.AttachmentUtils;
 import com.example.majifix311.utils.EmptyErrorTrigger;
 
 import java.util.List;
 
 import io.reactivex.functions.Consumer;
-
-import static android.view.View.GONE;
 
 /**
  * This activity is for submitting problems to a municipal company that uses the majifix system.
@@ -66,9 +62,10 @@ public class ReportProblemActivity extends FragmentActivity implements View.OnCl
 
     private ImageView mIvLocation;
     private TextView mTvLocationError;
-    private LinearLayout mLlPhoto;
-    private ImageView mIvPhoto;
-    private String mAttachmentUrl;
+    private AttachmentButton mAbPhoto;
+    //private LinearLayout mLlPhoto;
+    //private ImageView mIvPhoto;
+    //private String mAttachmentUrl;
 
     private Button mSubmitButton;
 
@@ -106,8 +103,9 @@ public class ReportProblemActivity extends FragmentActivity implements View.OnCl
         mEtDescription = (EditText) findViewById(R.id.et_description);
         mIvLocation = (ImageView) findViewById(R.id.iv_location);
         mTvLocationError = (TextView) findViewById(R.id.tv_location_error);
-        mLlPhoto = (LinearLayout) findViewById(R.id.ll_add_photo);
-        mIvPhoto = (ImageView) findViewById(R.id.iv_add_photo);
+        mAbPhoto = (AttachmentButton) findViewById(R.id.ab_add_photo);
+        //mLlPhoto = (LinearLayout) findViewById(R.id.ll_add_photo);
+        //mIvPhoto = (ImageView) findViewById(R.id.iv_add_photo);
 
         // for required fields: watch for text changes, and if empty, display error
         mEtName.addTextChangedListener(new EmptyErrorTrigger(mTilName));
@@ -137,14 +135,12 @@ public class ReportProblemActivity extends FragmentActivity implements View.OnCl
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
 
-        // Intent was fired to capture photo. Display thumbnail in given imageview.
-        boolean photoCaptureSuccess = AttachmentUtils.setThumbnailFromActivityResult(
-                mIvPhoto, mAttachmentUrl, requestCode, resultCode, data);
-        if (!photoCaptureSuccess) {
-            // If photo cannot be found, reset state
-            mAttachmentUrl = null;
-        } else {
-            Attachment attachment = AttachmentUtils.getPicAsAttachment(mAttachmentUrl);
+        // Attachment button will handle result of camera or file intents, and display image
+        boolean photoCapturedSuccess = mAbPhoto.displayOnActivityResult(requestCode, resultCode, data);
+
+        // If sucess, add attachment to problem.
+       if (photoCapturedSuccess) {
+            Attachment attachment = AttachmentUtils.getPicAsAttachment(mAbPhoto.getAttachmentUrl());
             mBuilder.addAttachment(attachment);
         }
     }
@@ -153,9 +149,11 @@ public class ReportProblemActivity extends FragmentActivity implements View.OnCl
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults);
 
+        // Attachment button will handle photo permissions requests
+        mAbPhoto.onRequestPermissionResult(requestCode, permissions, grantResults);
         // Check if this is a storage permission. If so, attempt to start camera.
-        mAttachmentUrl = AttachmentUtils.onRequestPermissionResult(
-                this, requestCode, permissions, grantResults);
+//        mAttachmentUrl = AttachmentUtils.onRequestPermissionResult(
+//                this, requestCode, permissions, grantResults);
     }
 
     private void setupCategoryPicker() {
@@ -187,20 +185,22 @@ public class ReportProblemActivity extends FragmentActivity implements View.OnCl
     }
 
     private void setupPhotoListener() {
+       // AttachmentUtils.setupAddAttachmentButton(this, mLlPhoto);
+
         // Check if phone is equipped with camera
-        if (this.getPackageManager().hasSystemFeature(PackageManager.FEATURE_CAMERA)) {
-            // If so, trigger camera on click
-            mLlPhoto.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
-                    // mAttachmentUrl will be used to retrieve the file in onActivityResult
-                    mAttachmentUrl = AttachmentUtils.dipatchTakePictureIntent(ReportProblemActivity.this);
-                }
-            });
-        } else {
-            // If not, hide camera icon and label
-            mLlPhoto.setVisibility(GONE);
-        }
+//        if (this.getPackageManager().hasSystemFeature(PackageManager.FEATURE_CAMERA)) {
+//            // If so, trigger camera on click
+//            mLlPhoto.setOnClickListener(new View.OnClickListener() {
+//                @Override
+//                public void onClick(View v) {
+//                    // mAttachmentUrl will be used to retrieve the file in displayOnActivityResult
+//                    mAttachmentUrl = AttachmentUtils.dipatchTakePictureIntent(ReportProblemActivity.this);
+//                }
+//            });
+//        } else {
+//            // If not, hide camera icon and label
+//            mLlPhoto.setVisibility(GONE);
+//        }
     }
 
     private void createCategoryPickerDialog(Category[] categories) {

--- a/majifix311/src/main/java/com/example/majifix311/ui/views/AttachmentButton.java
+++ b/majifix311/src/main/java/com/example/majifix311/ui/views/AttachmentButton.java
@@ -1,0 +1,148 @@
+package com.example.majifix311.ui.views;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.ContextWrapper;
+import android.content.Intent;
+import android.content.res.TypedArray;
+import android.os.Build;
+import android.support.annotation.Nullable;
+import android.util.AttributeSet;
+import android.view.Gravity;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.PopupMenu;
+
+import com.example.majifix311.R;
+import com.example.majifix311.models.Attachment;
+import com.example.majifix311.utils.AttachmentUtils;
+
+/**
+ * This is a drag and drop element that will, when clicked, show a dialog with options to either
+ * start a camera or select from gallery.
+ *
+ * To have the view automatically display the user chosen picture, call the attachment button
+ * in `displayOnActivityResult` and in `onRequestPermissionResult`.
+ */
+
+public class AttachmentButton extends LinearLayout {
+    private static final int REQUEST_IMAGE_CAPTURE = 1;
+    private static final int REQUEST_BROWSE_MEDIA_STORE = 2;
+    private static final int REQUEST_EXTERNAL_STORAGE_PERMISSION = 3;
+
+    private int mLayoutRes;
+    private int mPreviewImageViewId;
+
+    private String mPendingImageUrl;
+
+    private ImageView mPreview;
+
+    public AttachmentButton(Context context) {
+        super(context);
+        init();
+    }
+
+    public AttachmentButton(Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+        setCustomAttributes(context, attrs);
+        init();
+    }
+
+    public AttachmentButton(Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        setCustomAttributes(context, attrs);
+        init();
+    }
+
+    private void setCustomAttributes(Context context, AttributeSet attrs) {
+        TypedArray a = context.getTheme().obtainStyledAttributes(
+                attrs, R.styleable.AttachmentButton, 0, 0);
+        try {
+            mLayoutRes = a.getInteger(R.styleable.AttachmentButton_ab_layout, R.layout.view_add_attachment);
+            mPreviewImageViewId = a.getInteger(R.styleable.AttachmentButton_ab_preview_id, R.id.iv_add_photo);
+        } finally {
+            a.recycle();
+        }
+    }
+
+    private void init() {
+        inflate(getContext(),mLayoutRes, this);
+        setOrientation(VERTICAL);
+
+        LayoutParams params = new LinearLayout.LayoutParams(
+                LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT);
+        params.gravity = Gravity.CENTER;
+        setLayoutParams(params);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            setGravity(TEXT_ALIGNMENT_CENTER);
+        }
+
+        mPreview = (ImageView) findViewById(mPreviewImageViewId);
+
+        setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                PopupMenu popup = new PopupMenu(getContext(), AttachmentButton.this);
+                MenuInflater inflater = popup.getMenuInflater();
+                inflater.inflate(R.menu.attachmenttype, popup.getMenu());
+                popup.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
+                    @Override
+                    public boolean onMenuItemClick(MenuItem item) {
+                        Activity activity = getActivity();
+                        if (activity != null) {
+                            if (item.getItemId() == R.id.action_start_gallery) {
+                                AttachmentUtils.dispatchAddFromGalleryIntent(activity);
+                            } else if (item.getItemId() == R.id.action_start_camera) {
+                                mPendingImageUrl = AttachmentUtils.dipatchTakePictureIntent(activity);
+                            }
+                            return true;
+                        }
+                        return false;
+                    }
+                });
+                popup.show();
+            }
+        });
+    }
+
+    public String getAttachmentUrl() {
+        return mPendingImageUrl;
+    }
+
+    public void setAttachmentUrl(String attachmentUrl) {
+        mPendingImageUrl = attachmentUrl;
+    }
+
+    public ImageView getPreviewImageView() {
+        return mPreview;
+    }
+
+    public void setPreviewImageView(ImageView imageView) {
+        mPreview = imageView;
+    }
+
+    public boolean displayOnActivityResult(int requestCode, int resultCode, Intent data) {
+        return AttachmentUtils.setThumbnailFromActivityResult(mPreview, mPendingImageUrl,
+                                                       requestCode, resultCode, data);
+    }
+
+    public void onRequestPermissionResult(int requestCode, String permissions[], int[] grantResults) {
+        mPendingImageUrl = AttachmentUtils.onRequestPermissionResult(
+                                    getActivity(), requestCode, permissions, grantResults);
+    }
+
+    private Activity getActivity() {
+        Context context = getContext();
+        while (context instanceof ContextWrapper) {
+            if (context instanceof Activity) {
+                return (Activity)context;
+            }
+            context = ((ContextWrapper)context).getBaseContext();
+        }
+        return null;
+    }
+}

--- a/majifix311/src/main/java/com/example/majifix311/ui/views/AttachmentButton.java
+++ b/majifix311/src/main/java/com/example/majifix311/ui/views/AttachmentButton.java
@@ -24,15 +24,18 @@ import com.example.majifix311.utils.AttachmentUtils;
  * This is a drag and drop element that will, when clicked, show a dialog with options to either
  * start a camera or select from gallery.
  *
- * To have the view automatically display the user chosen picture, call the attachment button
- * in `displayOnActivityResult` and in `onRequestPermissionResult`.
+ * To have the view handle the intent correctly, please call `button.displayOnActivityResult()`
+ * and `button.onRequestPermissionResult()` in the Activity lifecycle methods. This will ensure
+ * that the AttachmentUrl is properly set, and the thumbnail is properly displayed in the
+ * 'mPreview' ImageView.
+ *
+ * Currently, it is possible to customize the layout used, via xml with `app:ab_layout`.
+ * To ensure the preview works as expected, also be sure to also provide `app:ab_preview_id`,
+ * or use the same id as used by the default layout (`R.id.iv_add_photo`).
+ *
  */
 
 public class AttachmentButton extends LinearLayout {
-    private static final int REQUEST_IMAGE_CAPTURE = 1;
-    private static final int REQUEST_BROWSE_MEDIA_STORE = 2;
-    private static final int REQUEST_EXTERNAL_STORAGE_PERMISSION = 3;
-
     private int mLayoutRes;
     private int mPreviewImageViewId;
 
@@ -66,6 +69,24 @@ public class AttachmentButton extends LinearLayout {
         } finally {
             a.recycle();
         }
+    }
+
+    public String getAttachmentUrl() {
+        return mPendingImageUrl;
+    }
+
+    public void setAttachmentUrl(String attachmentUrl) {
+        mPendingImageUrl = attachmentUrl;
+    }
+
+    public boolean displayOnActivityResult(int requestCode, int resultCode, Intent data) {
+        return AttachmentUtils.setThumbnailFromActivityResult(mPreview, mPendingImageUrl,
+                                                       requestCode, resultCode, data);
+    }
+
+    public void onRequestPermissionResult(int requestCode, String permissions[], int[] grantResults) {
+        mPendingImageUrl = AttachmentUtils.onRequestPermissionResult(
+                                    getActivity(), requestCode, permissions, grantResults);
     }
 
     private void init() {
@@ -107,32 +128,6 @@ public class AttachmentButton extends LinearLayout {
                 popup.show();
             }
         });
-    }
-
-    public String getAttachmentUrl() {
-        return mPendingImageUrl;
-    }
-
-    public void setAttachmentUrl(String attachmentUrl) {
-        mPendingImageUrl = attachmentUrl;
-    }
-
-    public ImageView getPreviewImageView() {
-        return mPreview;
-    }
-
-    public void setPreviewImageView(ImageView imageView) {
-        mPreview = imageView;
-    }
-
-    public boolean displayOnActivityResult(int requestCode, int resultCode, Intent data) {
-        return AttachmentUtils.setThumbnailFromActivityResult(mPreview, mPendingImageUrl,
-                                                       requestCode, resultCode, data);
-    }
-
-    public void onRequestPermissionResult(int requestCode, String permissions[], int[] grantResults) {
-        mPendingImageUrl = AttachmentUtils.onRequestPermissionResult(
-                                    getActivity(), requestCode, permissions, grantResults);
     }
 
     private Activity getActivity() {

--- a/majifix311/src/main/java/com/example/majifix311/utils/AttachmentUtils.java
+++ b/majifix311/src/main/java/com/example/majifix311/utils/AttachmentUtils.java
@@ -1,0 +1,272 @@
+package com.example.majifix311.utils;
+
+import android.Manifest;
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.Matrix;
+import android.media.ExifInterface;
+import android.net.Uri;
+import android.os.Bundle;
+import android.os.Environment;
+import android.provider.MediaStore;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
+import android.support.v4.content.FileProvider;
+import android.widget.ImageView;
+
+import java.io.File;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import static android.app.Activity.RESULT_OK;
+
+/**
+ * This works to contain the logic involved in taking pictures using the phones camera
+ * as well as retrieving files from the phone file system.
+ *
+ * For more information, take a look at:
+ *  https://developer.android.com/training/camera/photobasics.html#TaskCaptureIntent
+ *
+ * For information on EXIF (used to fix Samsung photo rotation bug), look here:
+ *  http://android-coding.blogspot.com/2011/10/read-exif-of-jpg-file-using.html
+ *  https://stackoverflow.com/questions/40864566/how-to-rotate-image-to-its-default-orientation-selected-from-gallery-in-android
+ */
+
+public class AttachmentUtils {
+    private static final int REQUEST_IMAGE_CAPTURE = 1;
+    private static final int REQUEST_EXTERNAL_STORAGE_PERMISSION = 2;
+
+    /** TAKE PICTURE: Step 1 -> Send Intent. This method only returns a thumbnail */
+    public static void dipatchTakePictureIntentForThumbnailOnly(Activity activity) {
+        Intent takePictureIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
+        // check to ensure that the activity component can handle the intent
+        if (takePictureIntent.resolveActivity(activity.getPackageManager()) != null) {
+            // This intent will return a bitmap in onActivityResult
+            activity.startActivityForResult(takePictureIntent, REQUEST_IMAGE_CAPTURE);
+        }
+    }
+
+    /** TAKE PICTURE: Step 1 (OPTION B) -> Send Intent to take picture and save file.
+     * Returns a uri that can be used to retrieve the full size image */
+    public static String dipatchTakePictureIntent(Activity activity) {
+        Intent takePictureIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
+        // check to ensure that the activity component can handle the intent
+        if (takePictureIntent.resolveActivity(activity.getPackageManager()) != null) {
+            // Create the File where the image should go
+            File photoFile = null;
+            try {
+                photoFile = createEmptyImageFile(activity);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+            // If file was created, start intent with uri. Intent will return in
+            // on ActivityResult. No Thumbnail will be sent, and file will need to be parsed.
+            if (photoFile != null) {
+                Uri photoUri = FileProvider.getUriForFile(activity,
+                        "com.example.majifix311.fileprovider",
+                        photoFile);
+                takePictureIntent.putExtra(MediaStore.EXTRA_OUTPUT, photoUri);
+                activity.startActivityForResult(takePictureIntent, REQUEST_IMAGE_CAPTURE);
+                return photoFile.getAbsolutePath();
+            }
+        }
+        return null;
+    }
+
+    /** TAKE PICTURE: Step 2 -> get thumbnail. This should be called in onActivityResult.
+     * Note: This will only work with dipatchTakePictureIntentForThumbnailOnly */
+    public static Bitmap setThumbnailFromActivityResult(int requestCode, int resultCode, Intent data) {
+        if (requestCode == REQUEST_IMAGE_CAPTURE && resultCode == RESULT_OK) {
+            if (data != null && data.getExtras() != null) {
+                return (Bitmap) data.getExtras().get("data");
+            }
+        }
+        return null;    }
+
+    /** TAKE PICTURE: Step 2 (OPTION B) -> This should be called in onActivityResult.
+     * This method will handle both the case where the image is saved in a file, and a simple
+     * thumbnail sent in the intent. It returns true when bitmap was found successfully. */
+    public static boolean setThumbnailFromActivityResult(ImageView imageView, String url,
+                                                        int requestCode, int resultCode, Intent data) {
+        if (requestCode == REQUEST_IMAGE_CAPTURE && resultCode == RESULT_OK) {
+            if (data == null) {
+                // assume image is saved in file
+                return setPicFromFile(imageView, url);
+            } else {
+                // use bitmap sent in intent
+                Bundle extras = data.getExtras();
+                Bitmap bitmap = (Bitmap) extras.get("data");
+                if (bitmap != null) {
+                    imageView.setImageBitmap(bitmap);
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /** Newer devices may require a permission check. Please call this onRequestPermissionResult in the Activity */
+    public static String onRequestPermissionResult(Activity activity, int requestCode, String permissions[], int[] grantResults) {
+        switch (requestCode) {
+            case REQUEST_EXTERNAL_STORAGE_PERMISSION :
+                if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                    return dipatchTakePictureIntent(activity);
+                } else {
+                    // permission denied... TODO Handle
+                }
+        }
+        return null;
+    }
+
+    /** The majiFix api expects a Base64 string as the content for it's attachments */
+    public static String getPicAsBase64String(String url) {
+        return null;
+    }
+
+    /** This extracts a photo from a file to sets it to a given imageview */
+    private static boolean setPicFromFile(ImageView view, String uri) {
+        if (view == null || uri == null) {
+            return false;
+        }
+
+        // Get dimens of the view
+        int targetW = view.getWidth();
+        int targetH = view.getHeight();
+
+        // Get dimens of bitmap
+        BitmapFactory.Options bmOptions = new BitmapFactory.Options();
+        bmOptions.inJustDecodeBounds = true;
+        BitmapFactory.decodeFile(uri, bmOptions);
+        int photoW = bmOptions.outWidth;
+        int photoH = bmOptions.outHeight;
+
+        // Determine how much to scale down the image
+        int scaleFactor = Math.min(photoW/targetW, photoH/targetH);
+
+        // Decode the image file into a Bitmap sized to fit the view
+        bmOptions.inJustDecodeBounds = false;
+        bmOptions.inSampleSize = scaleFactor;
+        bmOptions.inPurgeable = true;
+        Bitmap bitmap = BitmapFactory.decodeFile(uri, bmOptions);
+
+        // Some devices (Samsung) save important rotation info into exif
+        // This information must be read, and image manually rotated
+        try {
+            logExif(uri);
+            bitmap = rotateImageBasedOnExifData(bitmap, uri);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        // Set bitmap in view
+        System.out.println("Bitmap decoded: "+bitmap);
+        view.setImageBitmap(bitmap);
+        return true;
+    }
+
+    /** Creates an empty file where we want to store photo data */
+    private static File createEmptyImageFile(Activity activity) throws IOException {
+        // In API 21+, external storage is considered a dangeorus permission that must be checked at runtime
+        int permissionCheck = ContextCompat.checkSelfPermission(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE);
+        if (permissionCheck == PackageManager.PERMISSION_GRANTED) {
+            // Create an image file name
+            String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
+            String imageFileName = "JPEG_" + timeStamp + "_";
+            File storageDirectory = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES);
+            System.out.println("File is at: "+storageDirectory.getAbsolutePath());
+            File image = File.createTempFile(imageFileName, ".jpg", storageDirectory);
+            System.out.println("File is at: "+image.getAbsolutePath());
+
+            // Ensure this file will be accessible to other apps
+            addPicToGalleryForExternalUse(activity, image.getAbsolutePath());
+            return image;
+        } else {
+            // TODO Add request permission message
+            //if (ActivityCompat.shouldShowRequestPermissionRationale(activity,
+                    //Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+                // Show explanation to user async, and try to request again
+            //} else {
+                // request
+                ActivityCompat.requestPermissions(activity, new String[]{
+                        Manifest.permission.WRITE_EXTERNAL_STORAGE},
+                        REQUEST_EXTERNAL_STORAGE_PERMISSION);
+                // answer will return onRequestPermissionResult in activity
+            //}
+        }
+        return null;
+    }
+
+    /** Makes photo available for all apps */
+    private static void addPicToGalleryForExternalUse(Context context, String photoAbsolutePath) {
+        Intent mediaScanIntent = new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE);
+        File file = new File(photoAbsolutePath);
+        Uri contentUri = Uri.fromFile(file);
+        mediaScanIntent.setData(contentUri);
+        context.sendBroadcast(mediaScanIntent);
+    }
+
+    /** Samsung devices store the rotation data in EXIF file, and image must be manually rotated */
+    private static Bitmap rotateImageBasedOnExifData(Bitmap bitmap, String photoPath) throws IOException {
+        ExifInterface exifInterface = new ExifInterface(photoPath);
+        int orientation = exifInterface.getAttributeInt(ExifInterface.TAG_ORIENTATION,
+                ExifInterface.ORIENTATION_UNDEFINED);
+
+        switch(orientation) {
+            case ExifInterface.ORIENTATION_ROTATE_90:
+                bitmap = rotateImage(bitmap, 90);
+                break;
+            case ExifInterface.ORIENTATION_ROTATE_180:
+                bitmap = rotateImage(bitmap, 180);
+                break;
+            case ExifInterface.ORIENTATION_ROTATE_270:
+                bitmap = rotateImage(bitmap, 270);
+                break;
+            case ExifInterface.ORIENTATION_NORMAL:
+            default:
+                break;
+        }
+        return bitmap;
+    }
+
+    private static Bitmap rotateImage(Bitmap bitmap, float degrees) {
+        System.out.println("Rotating image: "+degrees);
+        Matrix matrix = new Matrix();
+        matrix.postRotate(degrees);
+        return Bitmap.createBitmap(bitmap, 0, 0, bitmap.getWidth(), bitmap.getHeight(), matrix, true);
+    }
+
+    private static void logExif(String file){
+        String exif="Exif: " + file;
+        try {
+            ExifInterface exifInterface = new ExifInterface(file);
+
+            exif += "\nIMAGE_LENGTH: " + exifInterface.getAttribute(ExifInterface.TAG_IMAGE_LENGTH);
+            exif += "\nIMAGE_WIDTH: " + exifInterface.getAttribute(ExifInterface.TAG_IMAGE_WIDTH);
+            exif += "\n DATETIME: " + exifInterface.getAttribute(ExifInterface.TAG_DATETIME);
+            exif += "\n TAG_MAKE: " + exifInterface.getAttribute(ExifInterface.TAG_MAKE);
+            exif += "\n TAG_MODEL: " + exifInterface.getAttribute(ExifInterface.TAG_MODEL);
+            exif += "\n TAG_ORIENTATION: " + exifInterface.getAttribute(ExifInterface.TAG_ORIENTATION);
+            exif += "\n TAG_WHITE_BALANCE: " + exifInterface.getAttribute(ExifInterface.TAG_WHITE_BALANCE);
+            exif += "\n TAG_FOCAL_LENGTH: " + exifInterface.getAttribute(ExifInterface.TAG_FOCAL_LENGTH);
+            exif += "\n TAG_FLASH: " + exifInterface.getAttribute(ExifInterface.TAG_FLASH);
+            exif += "\nGPS related:";
+            exif += "\n TAG_GPS_DATESTAMP: " + exifInterface.getAttribute(ExifInterface.TAG_GPS_DATESTAMP);
+            exif += "\n TAG_GPS_TIMESTAMP: " + exifInterface.getAttribute(ExifInterface.TAG_GPS_TIMESTAMP);
+            exif += "\n TAG_GPS_LATITUDE: " + exifInterface.getAttribute(ExifInterface.TAG_GPS_LATITUDE);
+            exif += "\n TAG_GPS_LATITUDE_REF: " + exifInterface.getAttribute(ExifInterface.TAG_GPS_LATITUDE_REF);
+            exif += "\n TAG_GPS_LONGITUDE: " + exifInterface.getAttribute(ExifInterface.TAG_GPS_LONGITUDE);
+            exif += "\n TAG_GPS_LONGITUDE_REF: " + exifInterface.getAttribute(ExifInterface.TAG_GPS_LONGITUDE_REF);
+            exif += "\n TAG_GPS_PROCESSING_METHOD: " + exifInterface.getAttribute(ExifInterface.TAG_GPS_PROCESSING_METHOD);
+
+            System.out.println(exif);
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/majifix311/src/main/res/drawable/ic_photo_library_black.xml
+++ b/majifix311/src/main/res/drawable/ic_photo_library_black.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M22,16L22,4c0,-1.1 -0.9,-2 -2,-2L8,2c-1.1,0 -2,0.9 -2,2v12c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2zM11,12l2.03,2.71L16,11l4,5L8,16l3,-4zM2,6v14c0,1.1 0.9,2 2,2h14v-2L4,20L4,6L2,6z"/>
+</vector>

--- a/majifix311/src/main/res/layout/activity_reporting_form.xml
+++ b/majifix311/src/main/res/layout/activity_reporting_form.xml
@@ -111,31 +111,7 @@
             android:id="@+id/ab_add_photo"
             android:layout_height="wrap_content"
             android:layout_width="0dp"
-            android:layout_weight="1"
-            app:layout="@layout/view_add_attachment"/>
-
-        <!--<LinearLayout-->
-            <!--android:id="@+id/ll_add_photo"-->
-            <!--android:layout_height="wrap_content"-->
-            <!--android:layout_width="0dp"-->
-            <!--android:layout_weight="1"-->
-            <!--android:orientation="vertical"-->
-            <!--android:layout_gravity="center"-->
-            <!--android:gravity="center">-->
-
-            <!--<ImageView-->
-                <!--android:id="@+id/iv_add_photo"-->
-                <!--android:src="@drawable/ic_add_photo_black"-->
-                <!--android:contentDescription="@string/content_desc_photo"-->
-                <!--android:layout_width="@dimen/form_icon"-->
-                <!--android:layout_height="@dimen/form_icon" />-->
-
-            <!--<TextView-->
-                <!--android:layout_width="wrap_content"-->
-                <!--android:layout_height="wrap_content"-->
-                <!--android:text="@string/hint_photo"/>-->
-
-        <!--</LinearLayout>-->
+            android:layout_weight="1" />
 
     </LinearLayout>
 

--- a/majifix311/src/main/res/layout/activity_reporting_form.xml
+++ b/majifix311/src/main/res/layout/activity_reporting_form.xml
@@ -117,6 +117,7 @@
             android:gravity="center">
 
             <ImageView
+                android:id="@+id/iv_add_photo"
                 android:src="@drawable/ic_add_photo_black"
                 android:contentDescription="@string/content_desc_photo"
                 android:layout_width="@dimen/form_icon"

--- a/majifix311/src/main/res/layout/activity_reporting_form.xml
+++ b/majifix311/src/main/res/layout/activity_reporting_form.xml
@@ -107,28 +107,35 @@
         </LinearLayout>
 
         <!-- Photo -->
-        <LinearLayout
-            android:id="@+id/ll_add_photo"
+        <com.example.majifix311.ui.views.AttachmentButton
+            android:id="@+id/ab_add_photo"
             android:layout_height="wrap_content"
             android:layout_width="0dp"
             android:layout_weight="1"
-            android:orientation="vertical"
-            android:layout_gravity="center"
-            android:gravity="center">
+            app:layout="@layout/view_add_attachment"/>
 
-            <ImageView
-                android:id="@+id/iv_add_photo"
-                android:src="@drawable/ic_add_photo_black"
-                android:contentDescription="@string/content_desc_photo"
-                android:layout_width="@dimen/form_icon"
-                android:layout_height="@dimen/form_icon" />
+        <!--<LinearLayout-->
+            <!--android:id="@+id/ll_add_photo"-->
+            <!--android:layout_height="wrap_content"-->
+            <!--android:layout_width="0dp"-->
+            <!--android:layout_weight="1"-->
+            <!--android:orientation="vertical"-->
+            <!--android:layout_gravity="center"-->
+            <!--android:gravity="center">-->
 
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/hint_photo"/>
+            <!--<ImageView-->
+                <!--android:id="@+id/iv_add_photo"-->
+                <!--android:src="@drawable/ic_add_photo_black"-->
+                <!--android:contentDescription="@string/content_desc_photo"-->
+                <!--android:layout_width="@dimen/form_icon"-->
+                <!--android:layout_height="@dimen/form_icon" />-->
 
-        </LinearLayout>
+            <!--<TextView-->
+                <!--android:layout_width="wrap_content"-->
+                <!--android:layout_height="wrap_content"-->
+                <!--android:text="@string/hint_photo"/>-->
+
+        <!--</LinearLayout>-->
 
     </LinearLayout>
 

--- a/majifix311/src/main/res/layout/view_add_attachment.xml
+++ b/majifix311/src/main/res/layout/view_add_attachment.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <ImageView
+        android:id="@+id/iv_add_photo"
+        android:src="@drawable/ic_add_photo_black"
+        android:contentDescription="@string/content_desc_photo"
+        android:layout_gravity="center"
+        android:layout_width="@dimen/form_icon"
+        android:layout_height="@dimen/form_icon" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="@string/hint_photo"/>
+
+</merge>

--- a/majifix311/src/main/res/menu/attachmenttype.xml
+++ b/majifix311/src/main/res/menu/attachmenttype.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:id="@+id/action_start_camera"
+        android:icon="@drawable/ic_add_photo_black"
+        android:title="@string/action_from_camera"/>
+    <item android:id="@+id/action_start_gallery"
+        android:icon="@drawable/ic_photo_library_black"
+        android:title="@string/action_from_gallery" />
+</menu>

--- a/majifix311/src/main/res/values/attrs.xml
+++ b/majifix311/src/main/res/values/attrs.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <declare-styleable name="AttachmentButton">
+        <attr name="ab_layout" format="integer" />
+        <attr name="ab_preview_id" format="integer" />
+    </declare-styleable>
+</resources>

--- a/majifix311/src/main/res/values/strings.xml
+++ b/majifix311/src/main/res/values/strings.xml
@@ -18,4 +18,6 @@
     <string name="action_select_category">What type of problem is this?</string>
     <string name="action_select">Select</string>
     <string name="action_close">Close</string>
+    <string name="action_from_camera">Take new photo</string>
+    <string name="action_from_gallery">Use existing photo</string>
 </resources>

--- a/majifix311/src/main/res/xml/file_paths.xml
+++ b/majifix311/src/main/res/xml/file_paths.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <external-path
+        name="majifix" path="Pictures/" />
+</paths>

--- a/majifix311/src/test/java/com/example/majifix311/ReportProblemActivityTest.java
+++ b/majifix311/src/test/java/com/example/majifix311/ReportProblemActivityTest.java
@@ -12,6 +12,7 @@ import com.example.majifix311.api.ReportService;
 import com.example.majifix311.models.Category;
 import com.example.majifix311.models.Problem;
 import com.example.majifix311.ui.ReportProblemActivity;
+import com.example.majifix311.ui.views.AttachmentButton;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -19,7 +20,9 @@ import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.Shadows;
 import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowActivity;
 
 import static com.example.majifix311.Mocks.mockCategoryCode;
 import static junit.framework.Assert.assertEquals;
@@ -40,6 +43,7 @@ public class ReportProblemActivityTest {
     private EditText mPhoneView;
     private EditText mCategoryView;
     private TextView mLocationError;
+    private AttachmentButton mAttachmentButton;
     private EditText mAddressView;
     private EditText mDescriptionView;
     private Button mSubmitButton;
@@ -59,6 +63,7 @@ public class ReportProblemActivityTest {
         mPhoneView = (EditText) mActivity.findViewById(R.id.et_phone);
         mCategoryView = (EditText) mActivity.findViewById(R.id.et_category);
         mLocationError = (TextView) mActivity.findViewById(R.id.tv_location_error);
+        mAttachmentButton = (AttachmentButton) mActivity.findViewById(R.id.ab_add_photo);
         mAddressView = (EditText) mActivity.findViewById(R.id.et_address);
         mDescriptionView = (EditText) mActivity.findViewById(R.id.et_description);
         mSubmitButton = (Button) mActivity.findViewById(R.id.btn_submit);
@@ -72,9 +77,17 @@ public class ReportProblemActivityTest {
         assertNotNull(mPhoneView);
         assertNotNull(mCategoryView);
         assertNotNull(mLocationError);
+        assertNotNull(mAttachmentButton);
         assertNotNull(mAddressView);
         assertNotNull(mDescriptionView);
         assertNotNull(mSubmitButton);
+    }
+
+    @Test
+    public void canAddAttachment() {
+        mAttachmentButton.performClick();
+
+        // TODO test this...
     }
 
     @Test


### PR DESCRIPTION
I have added two main classes that I am adding in this PR:

- an `AttachmentUtils` that contains static methods used to send and respond to camera and media intents, create files, manipulate bitmaps, etc.
- a `AttachmentButton` custom view that is used for one attachment. It displays a dialog allowing the user to choose between camera and gallery, starts the proper intent, and can be called in the activity lifecycle methods to properly respond to said intents to display a thumbnail of the chosen/taken photo. The url of the attachment is saved in the view, and can be retrieved with `button.getAttachmentUrl()`. The layout and preview view can be customized to fit the ui.

So, the idea is that to add three attachments to a form, such as in the "New Connection" page of the DAWASCO app, a developer could use three `AttachmentButton` views, one for the photo, one for the id, one for the housing contract, etc.